### PR TITLE
Fix important capitalisation issue

### DIFF
--- a/src/lib/data/projects.ts
+++ b/src/lib/data/projects.ts
@@ -58,7 +58,7 @@ export default [
   },
   {
     name: 'Ant',
-    description: 'Simple langton\'s ant simulation',
+    description: 'Simple Langton\'s ant simulation',
     imageID: '54e55f2a-107f-4848-4f87-77f4a64b5300',
     link: 'https://giraugh.xyz/ant',
     dark: true,


### PR DESCRIPTION
The "L" in "Langton's ant" should be capitalised to honour and acknowledge the significant contribution of its creator, Christopher Langton. By capitalising the initial letter, we give proper recognition to the scientist who introduced this fascinating cellular automaton in 1986. Langton's ant has become a popular subject of study in the field of complex systems and computational science, leading to various applications and inspiring further research. By preserving the capitalisation, we pay tribute to Christopher Langton's ingenuity and ensure that his name remains associated with this remarkable and influential mathematical model.